### PR TITLE
Native shortcut parser

### DIFF
--- a/TileIconifier/TileIconifier.csproj
+++ b/TileIconifier/TileIconifier.csproj
@@ -138,6 +138,17 @@
   <ItemGroup>
     <None Include="App.config" />
   </ItemGroup>
+  <ItemGroup>
+    <COMReference Include="IWshRuntimeLibrary">
+      <Guid>{F935DC20-1CF0-11D0-ADB9-00C04FD58A0B}</Guid>
+      <VersionMajor>1</VersionMajor>
+      <VersionMinor>0</VersionMinor>
+      <Lcid>0</Lcid>
+      <WrapperTool>tlbimp</WrapperTool>
+      <Isolated>False</Isolated>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </COMReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/TileIconifier/Utilities/ShortcutItem.cs
+++ b/TileIconifier/Utilities/ShortcutItem.cs
@@ -19,7 +19,8 @@ namespace TileIconifier
             get
             {
                 if (string.IsNullOrEmpty(_exeFilePath))
-                    _exeFilePath = ShortcutUtils.GetShortcutTarget(ShortcutFileInfo.FullName);
+                    _exeFilePath = ShortcutUtils.ResolveShortcut(ShortcutFileInfo.FullName);
+                    //_exeFilePath = ShortcutUtils.GetShortcutTarget(ShortcutFileInfo.FullName);
                 return string.Equals(Path.GetExtension(_exeFilePath), ".exe", StringComparison.InvariantCultureIgnoreCase) ? _exeFilePath : null;
             }
         }

--- a/TileIconifier/Utilities/ShortcutItem.cs
+++ b/TileIconifier/Utilities/ShortcutItem.cs
@@ -20,7 +20,6 @@ namespace TileIconifier
             {
                 if (string.IsNullOrEmpty(_exeFilePath))
                     _exeFilePath = ShortcutUtils.ResolveShortcut(ShortcutFileInfo.FullName);
-                    //_exeFilePath = ShortcutUtils.GetShortcutTarget(ShortcutFileInfo.FullName);
                 return string.Equals(Path.GetExtension(_exeFilePath), ".exe", StringComparison.InvariantCultureIgnoreCase) ? _exeFilePath : null;
             }
         }


### PR DESCRIPTION
Replaced custom shortcut parsing utility with native COM object.

The custom code would break with some shortcuts, for example JetBrain IDE shortcuts (not sure if it's the format or encoding or what).