### PR TITLE
Fix steam parsing

### DIFF
--- a/TileIconifier/Custom/CustomShortcut.cs
+++ b/TileIconifier/Custom/CustomShortcut.cs
@@ -163,7 +163,7 @@ namespace TileIconifier.Custom
             var vbsFileContents = File.ReadAllText(vbsFilePath);
 
             var regexMatch = Regex.Match(vbsFileContents,
-                "'Custom Shortcut Type = \"(.*)\".*'Shortcut Name = \"(.*)\".*'Shortcut Path = \"(.*)\".*targetPath = \"(.*)\".*targetArguments = \"(.*)\"\r\n.*",
+                "'Custom Shortcut Type = \"(.*)\".*'Shortcut Name = \"(.*)\".*'Shortcut Path = \"(.*)\".*targetPath = \"(.*)\".*targetArguments = \"(.*)\".*",
                 RegexOptions.Singleline);
 
             if (!regexMatch.Success)

--- a/TileIconifier/Custom/CustomShortcut.cs
+++ b/TileIconifier/Custom/CustomShortcut.cs
@@ -163,7 +163,7 @@ namespace TileIconifier.Custom
             var vbsFileContents = File.ReadAllText(vbsFilePath);
 
             var regexMatch = Regex.Match(vbsFileContents,
-                "'Custom Shortcut Type = \"(.*)\".*'Shortcut Name = \"(.*)\".*'Shortcut Path = \"(.*)\".*targetPath = \"(.*)\".*targetArguments = \"(.*)\".*",
+                "'Custom Shortcut Type = \"(.*)\".*'Shortcut Name = \"(.*)\".*'Shortcut Path = \"(.*)\".*targetPath = \"(.*)\".*targetArguments = \"(.*)\"\r?\n.*",
                 RegexOptions.Singleline);
 
             if (!regexMatch.Success)

--- a/TileIconifier/Steam/SteamLibrary.cs
+++ b/TileIconifier/Steam/SteamLibrary.cs
@@ -111,6 +111,19 @@ namespace TileIconifier.Steam
                 throw new SteamLibraryPathNotFoundException();
         }
 
+        private string GetGameName(KeyValues.KeyValues kv)
+        {
+            var kvp = kv.KeyNameValues.FirstOrDefault(k => k.Key.Equals("name", StringComparison.InvariantCultureIgnoreCase));
+            if (kvp != null)
+                return kvp.Value;
+            
+            var userConfigKv = kv.KeyChilds.FirstOrDefault(c => c.Name.Equals("UserConfig", StringComparison.InvariantCultureIgnoreCase));
+            if (userConfigKv != null)
+                return GetGameName(userConfigKv);
+
+            return null;
+        }
+
         public List<SteamGame> GetAllSteamGames()
         {
             var steamGames = new List<SteamGame>();
@@ -123,7 +136,9 @@ namespace TileIconifier.Steam
                     var kv = new KeyValues.KeyValues("AppState");
                     kv.LoadFromFile(acfFile.FullName);
                     var appId = kv.KeyNameValues.Single(k => k.Key == "appid").Value;
-                    var gameName = kv.KeyNameValues.Single(k => k.Key == "name").Value;
+                    var gameName = GetGameName(kv);
+                    if (gameName == null)
+                        continue;
                     steamGames.Add(new SteamGame(appId, gameName, acfFile.FullName));
                 }
             }


### PR DESCRIPTION
Fixed a few bugs.

1) Parse steam manifest like this:

```
"AppState"
{
	"appid"		"33650"
	"Universe"		"1"
	"StateFlags"		"4"
	"installdir"		"PuzzlerWorld"
	"LastUpdated"		"1386287844"
	"UpdateResult"		"0"
	"SizeOnDisk"		"52211113"
	"buildid"		"0"
	"LastOwner"		"76561198066521419"
	"BytesToDownload"		"42764224"
	"BytesDownloaded"		"42764224"
	"AutoUpdateBehavior"		"0"
	"AllowOtherDownloadsWhileRunning"		"0"
	"UserConfig"
	{
		"name"		"Puzzler World "
		"gameid"		"33650"
		"language"		"english"
	}
	"MountedDepots"
	{
		"33651"		"7241674082246559718"
	}
}
```

2) More permissive regex, without `\r\n` part. This was crashing on my system.